### PR TITLE
Potential fix for code scanning alert no. 21: Information exposure through an exception

### DIFF
--- a/src/dashboard/routes/api.py
+++ b/src/dashboard/routes/api.py
@@ -3,6 +3,13 @@ from dashboard.models import user
 from dashboard.models import pick  # Use absolute imports instead of relative
 import asyncio
 import logging
+
+# Configure logging
+logging.basicConfig(
+    level=logging.ERROR,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 from bot.bot import bot
 
 bp = Blueprint('api', __name__, url_prefix='/api')

--- a/src/dashboard/routes/api.py
+++ b/src/dashboard/routes/api.py
@@ -3,6 +3,7 @@ from dashboard.models import user
 from dashboard.models import pick  # Use absolute imports instead of relative
 import asyncio
 import logging
+from bot.bot import bot
 
 # Configure logging
 logging.basicConfig(
@@ -10,7 +11,6 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
-from bot.bot import bot
 
 bp = Blueprint('api', __name__, url_prefix='/api')
 

--- a/src/dashboard/routes/api.py
+++ b/src/dashboard/routes/api.py
@@ -2,7 +2,7 @@ from flask import Blueprint, jsonify, request
 from dashboard.models import user
 from dashboard.models import pick  # Use absolute imports instead of relative
 import asyncio
-
+import logging
 from bot.bot import bot
 
 bp = Blueprint('api', __name__, url_prefix='/api')
@@ -44,9 +44,10 @@ def get_leaderboard():
             ]
         })
     except Exception as e:
+        logging.error("Error in get_leaderboard: %s", str(e))
         return jsonify({
             'success': False,
-            'error': str(e)
+            'error': 'An internal error has occurred.'
         }), 500
 
 # TODO: Complete the implementation
@@ -99,7 +100,8 @@ def create_match():
         }), 201
 
     except Exception as e:
+        logging.error("Error in create_match: %s", str(e))
         return jsonify({
             'success': False,
-            'error': str(e)
+            'error': 'An internal error has occurred.'
         }), 500

--- a/src/dashboard/routes/api.py
+++ b/src/dashboard/routes/api.py
@@ -107,7 +107,7 @@ def create_match():
         }), 201
 
     except Exception as e:
-        logging.error("Error in create_match: %s", str(e))
+        logging.error("Error in create_match: %s", str(e), exc_info=True)
         return jsonify({
             'success': False,
             'error': 'An internal error has occurred.'


### PR DESCRIPTION
Potential fix for [https://github.com/WxboySuper/Esports-Pickem-Discord-Bot/security/code-scanning/21](https://github.com/WxboySuper/Esports-Pickem-Discord-Bot/security/code-scanning/21)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

Specifically, we will:
1. Import the `logging` module to enable logging of exceptions.
2. Replace the current exception handling code to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
