### PR TITLE
Potential fix for code scanning alert no. 20: Information exposure through an exception

### DIFF
--- a/src/dashboard/routes/admin.py
+++ b/src/dashboard/routes/admin.py
@@ -156,10 +156,10 @@ def update_match(match_id):
 
     except KeyError as e:
         admin_logger.error("Missing required field: %s", e)
-        return jsonify({'error': f'Missing required field: {str(e)}'}), 400
+        return jsonify({'error': 'Missing required field'}), 400
     except Exception as e:
         admin_logger.error("Error updating match: %s", e)
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'error': 'An internal error has occurred'}), 400
 
 @bp.route('/leaderboard')
 def leaderboard():


### PR DESCRIPTION
Potential fix for [https://github.com/WxboySuper/Esports-Pickem-Discord-Bot/security/code-scanning/20](https://github.com/WxboySuper/Esports-Pickem-Discord-Bot/security/code-scanning/20)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

Specifically, we need to:
1. Log the detailed exception message using the `admin_logger`.
2. Return a generic error message in the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
